### PR TITLE
increase maxBuffer on tesseract execution

### DIFF
--- a/lib/ocr.js
+++ b/lib/ocr.js
@@ -26,8 +26,9 @@ module.exports = function(input_path, options, callback) {
     // get a temp output path
     var output_path = temp.path({prefix: 'ocr_output'});
     // output_path = path.join(__dirname,'test/test_data/single_page_raw');
+    var procoptions = { maxBuffer: 4096 * 4096 };
     var cmd = 'tesseract "'+input_path+'" "'+output_path+'" '+options.join(' ');
-    var child = exec(cmd, function (err, stdout, stderr) {
+    var child = exec(cmd, procoptions, function (err, stdout, stderr) {
       if (err) { return callback(err); }
       // tesseract automatically appends ".txt" to the output file name
       var text_output_path = output_path+'.txt';


### PR DESCRIPTION
While using german trained data, the child process will use to much memory and fail.